### PR TITLE
Update bingo.json

### DIFF
--- a/bingo.json
+++ b/bingo.json
@@ -83,7 +83,7 @@
             "name": "Clear Ghosts in {X} Rooms",
             "variants": [
                 [5,  "2"],
-                [4,  "4"],
+                [14, "4"],
                 [19, "6"]
             ],
             "types": ["ghost"]


### PR DESCRIPTION
I'm guessing it was a typo to have 4 ghost rooms at an easier tier than 2 ghost rooms; revised from 4 to 14